### PR TITLE
Pin dependency base-x@3.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "rollup-plugin-node-resolve": "^4.0.0"
   },
   "dependencies": {
-    "base-x": "^3.0.5",
+    "base-x": "3.0.4",
     "bech32": "^1.1.3",
     "hash.js": "^1.1.7"
   }


### PR DESCRIPTION
base-x introduced ES6 syntax in 3.0.5, which breaks minification for browsers (see cryptocoinjs/base-x#51). This requires base-x at version 3.0.4 to fix the issue, until base-x releases a new version.