### PR TITLE
fix bech32 validation bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,11 +68,16 @@ const validateBech32 = (address) => {
 
 const validateBtcAddress = (address) => {
   let decoded;
+  let prefix = address.substr(0, 2)
+
+  if (prefix === 'bc' || prefix == 'tb') {
+    return validateBech32(address);
+  }
 
   try {
     decoded = base58.decode(address);
   } catch (error) {
-    return validateBech32(address);
+    return false;
   }
 
   const { length } = decoded;

--- a/test/index.js
+++ b/test/index.js
@@ -43,10 +43,16 @@ describe('Validator', () => {
   });
 
   it('validates Mainnet Bech32 P2WPKH', () => {
-    const address = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+    let addresses = [
+      'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+      'bc1q973xrrgje6etkkn9q9azzsgpxeddats8ckvp5s',
+    ];
 
-    assert.isNotFalse(validate(address));
-    assert.include(validate(address), { bech32: true, type: 'p2wpkh', testnet: false });
+    assert.isNotFalse(validate(addresses[0]));
+    assert.include(validate(addresses[0]), { bech32: true, type: 'p2wpkh', testnet: false });
+
+    assert.isNotFalse(validate(addresses[1]));
+    assert.include(validate(addresses[1]), { bech32: true, type: 'p2wpkh', testnet: false });
   });
 
   it('validates Testnet Bech32 P2WPKH', () => {


### PR DESCRIPTION
fix bech32 validation bug where some would be classified as base58check addresses
The address "bc1q973xrrgje6etkkn9q9azzsgpxeddats8ckvp5s" coming from my wallet would pass the "base58.decode" and get miscategorized then fail.