### PR TITLE
Add Bech32 regtest address support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ const validateBech32 = (address) => {
     return false;
   }
 
-  if (!['bc', 'tb'].includes(decoded.prefix)) {
+  if (!['bc', 'tb', 'bcrt'].includes(decoded.prefix)) {
     return false;
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -74,6 +74,13 @@ describe('Validator', () => {
     assert.include(validate(address), { bech32: true, type: 'p2wpkh', testnet: true });
   });
 
+  it('validates Regtest Bech32 P2WPKH', () => {
+    const address = 'bcrt1q6z64a43mjgkcq0ul2znwneq3spghrlau9slefp';
+
+    assert.isNotFalse(validate(address));
+    assert.include(validate(address), { bech32: true, type: 'p2wpkh', testnet: true });
+  });
+
   it('validates Mainnet Bech32 P2WSH', () => {
     const address = 'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3';
 
@@ -83,6 +90,13 @@ describe('Validator', () => {
 
   it('validates Testnet Bech32 P2WSH', () => {
     const address = 'tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7';
+
+    assert.isNotFalse(validate(address));
+    assert.include(validate(address), { bech32: true, type: 'p2wsh', testnet: true });
+  });
+
+  it('validates Regtest Bech32 P2WSH', () => {
+    const address = 'bcrt1q5n2k3frgpxces3dsw4qfpqk4kksv0cz96pldxdwxrrw0d5ud5hcqzzx7zt';
 
     assert.isNotFalse(validate(address));
     assert.include(validate(address), { bech32: true, type: 'p2wsh', testnet: true });


### PR DESCRIPTION
The Issue:
Regtest bech32 addresses have a 'bcrt' prefix, which was not included in the list in line 41 of index.js. This in turn meant that valid bech32 regtest addresses being fed to the library were returning false/invalid.

The Solution: 
I added the 'bcrt' prefix to the list of allowed prefixes and added appropriate testing. You may notice that this means that regtest addresses would also return 'testnet = True'. I accepted this as an appropriate approach since non-bech32 regtest addresses were already returning that. This also makes sense since legacy testnet and regtest addresses are the same. 