### PR TITLE
Add Strict Validation / Change testnet to network

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "url": "https://github.com/ruigomeseu/bitcoin-address-validation"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.3",
     "chai": "^4.2.0",
     "codecov": "^3.1.0",
     "cross-env": "^5.2.0",
@@ -41,7 +42,6 @@
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-react": "^7.11.1",
-    "istanbul": "^0.4.5",
     "mocha": "^6.1.4",
     "nyc": "^14.1.1",
     "rimraf": "^2.6.3",
@@ -53,6 +53,6 @@
   "dependencies": {
     "base-x": "^3.0.6",
     "bech32": "^1.1.3",
-    "hash.js": "^1.1.7"
+    "sha.js": "^2.4.11"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,7 +27,7 @@ export default [
       'base-x',
       'buffer',
       'bech32',
-      'hash.js/lib/hash/sha/256'
+      'sha.js'
     ],
     output: [
       { file: pkg.main, format: 'cjs' },

--- a/test/index.js
+++ b/test/index.js
@@ -6,14 +6,14 @@ describe('Validator', () => {
     const address = '17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem';
 
     assert.isNotFalse(validate(address));
-    assert.include(validate(address), { type: 'p2pkh', testnet: false, bech32: false });
+    assert.include(validate(address), { type: 'p2pkh', network: 'mainnet', bech32: false });
   });
 
   it('validates Testnet P2PKH', () => {
     const address = 'mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn';
 
     assert.isNotFalse(validate(address));
-    assert.include(validate(address), { type: 'p2pkh', testnet: true, bech32: false });
+    assert.include(validate(address), { type: 'p2pkh', network: 'testnet', bech32: false });
   });
 
   it('fails on invalid P2PKH', () => {
@@ -26,14 +26,14 @@ describe('Validator', () => {
     const address = '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy';
 
     assert.isNotFalse(validate(address));
-    assert.include(validate(address), { type: 'p2sh', testnet: false, bech32: false });
+    assert.include(validate(address), { type: 'p2sh', network: 'mainnet', bech32: false });
   });
 
   it('validates Testnet P2SH', () => {
     const address = '2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc';
 
     assert.isNotFalse(validate(address));
-    assert.include(validate(address), { type: 'p2sh', testnet: true, bech32: false });
+    assert.include(validate(address), { type: 'p2sh', network: 'testnet', bech32: false });
   });
 
   it('fails on invalid P2SH', () => {
@@ -55,56 +55,153 @@ describe('Validator', () => {
   });
 
   it('validates Mainnet Bech32 P2WPKH', () => {
-    let addresses = [
+    const addresses = [
       'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
       'bc1q973xrrgje6etkkn9q9azzsgpxeddats8ckvp5s',
     ];
 
     assert.isNotFalse(validate(addresses[0]));
-    assert.include(validate(addresses[0]), { bech32: true, type: 'p2wpkh', testnet: false });
+    assert.include(validate(addresses[0]), { bech32: true, type: 'p2wpkh', network: 'mainnet' });
 
     assert.isNotFalse(validate(addresses[1]));
-    assert.include(validate(addresses[1]), { bech32: true, type: 'p2wpkh', testnet: false });
+    assert.include(validate(addresses[1]), { bech32: true, type: 'p2wpkh', network: 'mainnet' });
   });
 
   it('validates Testnet Bech32 P2WPKH', () => {
     const address = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx';
 
     assert.isNotFalse(validate(address));
-    assert.include(validate(address), { bech32: true, type: 'p2wpkh', testnet: true });
+    assert.include(validate(address), { bech32: true, type: 'p2wpkh', network: 'testnet' });
   });
 
   it('validates Regtest Bech32 P2WPKH', () => {
     const address = 'bcrt1q6z64a43mjgkcq0ul2znwneq3spghrlau9slefp';
 
     assert.isNotFalse(validate(address));
-    assert.include(validate(address), { bech32: true, type: 'p2wpkh', testnet: true });
+    assert.include(validate(address), { bech32: true, type: 'p2wpkh', network: 'testnet' });
   });
 
   it('validates Mainnet Bech32 P2WSH', () => {
     const address = 'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3';
 
     assert.isNotFalse(validate(address));
-    assert.include(validate(address), { bech32: true, type: 'p2wsh', testnet: false });
+    assert.include(validate(address), { bech32: true, type: 'p2wsh', network: 'mainnet' });
   });
 
   it('validates Testnet Bech32 P2WSH', () => {
     const address = 'tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7';
 
     assert.isNotFalse(validate(address));
-    assert.include(validate(address), { bech32: true, type: 'p2wsh', testnet: true });
+    assert.include(validate(address), { bech32: true, type: 'p2wsh', network: 'testnet' });
   });
 
   it('validates Regtest Bech32 P2WSH', () => {
     const address = 'bcrt1q5n2k3frgpxces3dsw4qfpqk4kksv0cz96pldxdwxrrw0d5ud5hcqzzx7zt';
 
     assert.isNotFalse(validate(address));
-    assert.include(validate(address), { bech32: true, type: 'p2wsh', testnet: true });
+    assert.include(validate(address), { bech32: true, type: 'p2wsh', network: 'testnet' });
   });
 
   it('fails on invalid Bech32', () => {
     const address = 'bc1qw508d6qejxtdg4y5r3zrrvary0c5xw7kv8f3t4';
 
     assert.isFalse(validate(address));
+  });
+});
+
+describe('Strict Validator', () => {
+  it('validates Mainnet P2PKH', () => {
+    const address = '17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem';
+
+    assert.isTrue(validate(address, 'mainnet'));
+  });
+
+  it('validates Testnet P2PKH', () => {
+    const address = 'mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn';
+
+    assert.isTrue(validate(address, 'testnet'));
+  });
+
+  it('fails on invalid P2PKH', () => {
+    const address = '17VZNX1SN5NtKa8UFFxwQbFeFc3iqRYhem';
+
+    assert.isFalse(validate(address, 'mainnet'));
+  });
+
+  it('validates Mainnet P2SH', () => {
+    const address = '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy';
+
+    assert.isTrue(validate(address, 'mainnet'));
+  });
+
+  it('validates Testnet P2SH', () => {
+    const address = '2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc';
+
+    assert.isTrue(validate(address, 'testnet'));
+  });
+
+  it('fails on invalid P2SH', () => {
+    const address = '17VZNX1SN5NtKa8UFFxwQbFFFc3iqRYhem';
+
+    assert.isFalse(validate(address, 'mainnet'));
+  });
+
+  it('handles null address', () => {
+    const address = null;
+
+    assert.isFalse(validate(address, 'mainnet'));
+  });
+
+  it('handles bogus address', () => {
+    const address = 'x';
+
+    assert.isFalse(validate(address, 'mainnet'));
+  });
+
+  it('validates Mainnet Bech32 P2WPKH', () => {
+    const addresses = [
+      'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+      'bc1q973xrrgje6etkkn9q9azzsgpxeddats8ckvp5s',
+    ];
+
+    assert.isTrue(validate(addresses[0], 'mainnet'));
+
+    assert.isTrue(validate(addresses[1], 'mainnet'));
+  });
+
+  it('validates Testnet Bech32 P2WPKH', () => {
+    const address = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx';
+
+    assert.isTrue(validate(address, 'testnet'));
+  });
+
+  it('validates Regtest Bech32 P2WPKH', () => {
+    const address = 'bcrt1q6z64a43mjgkcq0ul2znwneq3spghrlau9slefp';
+
+    assert.isTrue(validate(address, 'testnet'));
+  });
+
+  it('validates Mainnet Bech32 P2WSH', () => {
+    const address = 'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3';
+
+    assert.isTrue(validate(address, 'mainnet'));
+  });
+
+  it('validates Testnet Bech32 P2WSH', () => {
+    const address = 'tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7';
+
+    assert.isTrue(validate(address, 'testnet'));
+  });
+
+  it('validates Regtest Bech32 P2WSH', () => {
+    const address = 'bcrt1q5n2k3frgpxces3dsw4qfpqk4kksv0cz96pldxdwxrrw0d5ud5hcqzzx7zt';
+
+    assert.isTrue(validate(address, 'testnet'));
+  });
+
+  it('fails on invalid Bech32', () => {
+    const address = 'bc1qw508d6qejxtdg4y5r3zrrvary0c5xw7kv8f3t4';
+
+    assert.isFalse(validate(address, 'mainnet'));
   });
 });


### PR DESCRIPTION
2 changes in this PR:

- (Breaking) Change testnet to network, as there's 3 possible networks using testnet only leaves regtest out of the equation (it's easy to differentiate a bech32 address from testnet/regtest, however I didn't find any info regarding differentiation for previous format)

- Add Strict Validation wrapper, for less verbose operation (useful when only caring for a single network), as it returns true or false only (must match validateBtcAddress conditions PLUS matching network)