### PR TITLE
Maintained DRY concepts in test script

### DIFF
--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -1,198 +1,84 @@
 import validate, { getAddressInfo, Network } from '../src/index';
 
-describe('Validation and parsing', () => {
-  it('validates Mainnet P2PKH', () => {
-    const address = '17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem';
+interface ITestParams {
+  network: string;
+  address: string | string[];
+  expect_valid: boolean;
+}
 
-    expect(validate(address)).not.toBe(false);
-    expect(getAddressInfo(address)).toEqual({ type: 'p2pkh', network: 'mainnet', bech32: false, address });
+describe.each([['Parsing'], ['Network']])('Validation & %s', (validationAndX) => {
+  describe('Bech32 = false', () => {
+    describe.each([['P2PKH'], ['P2SH']])('%s', (type) => {
+      // prettier-ignore-start
+      it.each`
+        network      | address                                                                                            | expect_valid
+        ${'Mainnet'} | ${type === 'P2PKH' ? '17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem' : '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy'}  | ${true}
+        ${'Testnet'} | ${type === 'P2PKH' ? 'mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn' : '2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc'} | ${true}
+        ${'fails'}   | ${type === 'P2PKH' ? '17VZNX1SN5NtKa8UFFxwQbFeFc3iqRYhem' : '17VZNX1SN5NtKa8UFFxwQbFFFc3iqRYhem'}  | ${false}
+      `(
+        // prettier-ignore-end
+        'validates $network for address=$address',
+        ({ network, address, expect_valid }: ITestParams) => {
+          address = address as string; // assign proper type
+          [type, network] = [type, network].map((x) => x.toLowerCase());
+
+          if (validationAndX === 'Parsing') {
+            expect(validate(address)).toBe(expect_valid);
+            if (expect_valid) {
+              expect(getAddressInfo(address)).toEqual({ type, network, bech32: false, address });
+            }
+          } else {
+            expect(validate(address, Network[network])).toBe(expect_valid);
+          }
+        },
+      );
+    });
+
+    describe('Errors/Fails', () => {
+      it('handles bogus address', () => {
+        expect(validate('x', validationAndX === 'Network' ? Network.mainnet : undefined)).toBe(false);
+      });
+    });
   });
 
-  it('validates Testnet P2PKH', () => {
-    const address = 'mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn';
+  describe('Bech32 = true', () => {
+    describe.each([['P2WPKH'], ['P2WSH']])('%s', (type) => {
+      // prettier-ignore-start
+      it.each`
+        network      | address                                                                                                                                                                                | expect_valid
+        ${'Mainnet'} | ${type === 'P2WPKH' ? ['bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4', 'bc1q973xrrgje6etkkn9q9azzsgpxeddats8ckvp5s'] : 'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3'} | ${true}
+        ${'Testnet'} | ${type === 'P2WPKH' ? 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx' : 'tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7'}                                                 | ${true}
+        ${'Regtest'} | ${type === 'P2WPKH' ? 'bcrt1q6z64a43mjgkcq0ul2znwneq3spghrlau9slefp' : 'bcrt1q5n2k3frgpxces3dsw4qfpqk4kksv0cz96pldxdwxrrw0d5ud5hcqzzx7zt'}                                             | ${true}
+      `(
+        // prettier-ignore-end
+        'validates $network for address=$address',
+        ({ network, address, expect_valid }: ITestParams) => {
+          address = Array.isArray(address) ? address : [address]; // convert all addresses to arrays for easy handling
+          [type, network] = [type, network].map((x) => x.toLowerCase());
 
-    expect(validate(address)).not.toBe(false);
-    expect(getAddressInfo(address)).toEqual({ type: 'p2pkh', network: 'testnet', bech32: false, address });
-  });
+          if (validationAndX === 'Parsing') {
+            address.forEach((address_item) => {
+              expect(validate(address_item)).toBe(expect_valid);
+              expect(getAddressInfo(address_item)).toEqual({ type, network, bech32: true, address: address_item });
+            });
+          } else {
+            address.forEach((address_item) => {
+              expect(validate(address_item, Network[network])).toBe(expect_valid);
+            });
+          }
+        },
+      );
+    });
 
-  it('fails on invalid P2PKH', () => {
-    const address = '17VZNX1SN5NtKa8UFFxwQbFeFc3iqRYhem';
+    describe('Errors/Fails', () => {
+      test('invalid Bech32', () => {
+        const address = 'bc1qw508d6qejxtdg4y5r3zrrvary0c5xw7kv8f3t4';
+        expect(validate(address, validationAndX === 'Network' ? Network.mainnet : undefined)).toBe(false);
+      });
 
-    expect(validate(address)).toBe(false);
-  });
-
-  it('validates Mainnet P2SH', () => {
-    const address = '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy';
-
-    expect(validate(address)).not.toBe(false);
-    expect(getAddressInfo(address)).toEqual({ type: 'p2sh', network: 'mainnet', bech32: false, address });
-  });
-
-  it('validates Testnet P2SH', () => {
-    const address = '2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc';
-
-    expect(validate(address)).not.toBe(false);
-    expect(getAddressInfo(address)).toEqual({ type: 'p2sh', network: 'testnet', bech32: false, address });
-  });
-
-  it('fails on invalid P2SH', () => {
-    const address = '17VZNX1SN5NtKa8UFFxwQbFFFc3iqRYhem';
-
-    expect(validate(address)).toBe(false);
-  });
-
-  it('handles bogus address', () => {
-    const address = 'x';
-
-    expect(validate(address)).toBe(false);
-  });
-
-  it('validates Mainnet Bech32 P2WPKH', () => {
-    const addresses = [
-      'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
-      'bc1q973xrrgje6etkkn9q9azzsgpxeddats8ckvp5s',
-    ];
-
-    expect(validate(addresses[0])).not.toBe(false);
-    expect(getAddressInfo(addresses[0])).toEqual({ bech32: true, type: 'p2wpkh', network: 'mainnet', address: addresses[0] });
-
-    expect(validate(addresses[1])).not.toBe(false);
-    expect(getAddressInfo(addresses[1])).toEqual({ bech32: true, type: 'p2wpkh', network: 'mainnet', address: addresses[1] });
-  });
-
-  it('validates Testnet Bech32 P2WPKH', () => {
-    const address = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx';
-
-    expect(validate(address)).not.toBe(false);
-    expect(getAddressInfo(address)).toEqual({ bech32: true, type: 'p2wpkh', network: 'testnet', address });
-  });
-
-  it('validates Regtest Bech32 P2WPKH', () => {
-    const address = 'bcrt1q6z64a43mjgkcq0ul2znwneq3spghrlau9slefp';
-
-    expect(validate(address)).not.toBe(false);
-    expect(getAddressInfo(address)).toEqual({ bech32: true, type: 'p2wpkh', network: 'regtest', address });
-  });
-
-  it('validates Mainnet Bech32 P2WSH', () => {
-    const address = 'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3';
-
-    expect(validate(address)).not.toBe(false);
-    expect(getAddressInfo(address)).toEqual({ bech32: true, type: 'p2wsh', network: 'mainnet', address });
-  });
-
-  it('validates Testnet Bech32 P2WSH', () => {
-    const address = 'tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7';
-
-    expect(validate(address)).not.toBe(false);
-    expect(getAddressInfo(address)).toEqual({ bech32: true, type: 'p2wsh', network: 'testnet', address });
-  });
-
-  it('validates Regtest Bech32 P2WSH', () => {
-    const address = 'bcrt1q5n2k3frgpxces3dsw4qfpqk4kksv0cz96pldxdwxrrw0d5ud5hcqzzx7zt';
-
-    expect(validate(address)).not.toBe(false);
-    expect(getAddressInfo(address)).toEqual({ bech32: true, type: 'p2wsh', network: 'regtest', address });
-  });
-
-  it('fails on invalid Bech32', () => {
-    const address = 'bc1qw508d6qejxtdg4y5r3zrrvary0c5xw7kv8f3t4';
-
-    expect(validate(address)).toBe(false);
-  });
-
-  it('errors on non-base58 encoded', () => {
-    expect(() => getAddressInfo('???')).toThrow();
-  });
-});
-
-describe('Validation & network', () => {
-  it('validates Mainnet P2PKH', () => {
-    const address = '17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem';
-
-    expect(validate(address, Network.mainnet)).toBe(true);
-  });
-
-  it('validates Testnet P2PKH', () => {
-    const address = 'mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn';
-
-    expect(validate(address, Network.testnet)).toBe(true);
-  });
-
-  it('fails on invalid P2PKH', () => {
-    const address = '17VZNX1SN5NtKa8UFFxwQbFeFc3iqRYhem';
-
-    expect(validate(address, Network.mainnet)).toBe(false);
-  });
-
-  it('validates Mainnet P2SH', () => {
-    const address = '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy';
-
-    expect(validate(address, Network.mainnet)).toBe(true);
-  });
-
-  it('validates Testnet P2SH', () => {
-    const address = '2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc';
-
-    expect(validate(address, Network.testnet)).toBe(true);
-  });
-
-  it('fails on invalid P2SH', () => {
-    const address = '17VZNX1SN5NtKa8UFFxwQbFFFc3iqRYhem';
-
-    expect(validate(address, Network.mainnet)).toBe(false);
-  });
-
-  it('handles bogus address', () => {
-    const address = 'x';
-
-    expect(validate(address, Network.mainnet)).toBe(false);
-  });
-
-  it('validates Mainnet Bech32 P2WPKH', () => {
-    const addresses = [
-      'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
-      'bc1q973xrrgje6etkkn9q9azzsgpxeddats8ckvp5s',
-    ];
-
-    expect(validate(addresses[0], Network.mainnet)).toBe(true);
-
-    expect(validate(addresses[1], Network.mainnet)).toBe(true);
-  });
-
-  it('validates Testnet Bech32 P2WPKH', () => {
-    const address = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx';
-
-    expect(validate(address, Network.testnet)).toBe(true);
-  });
-
-  it('validates Regtest Bech32 P2WPKH', () => {
-    const address = 'bcrt1q6z64a43mjgkcq0ul2znwneq3spghrlau9slefp';
-
-    expect(validate(address, Network.regtest)).toBe(true);
-  });
-
-  it('validates Mainnet Bech32 P2WSH', () => {
-    const address = 'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3';
-
-    expect(validate(address, Network.mainnet)).toBe(true);
-  });
-
-  it('validates Testnet Bech32 P2WSH', () => {
-    const address = 'tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7';
-
-    expect(validate(address, Network.testnet)).toBe(true);
-  });
-
-  it('validates Regtest Bech32 P2WSH', () => {
-    const address = 'bcrt1q5n2k3frgpxces3dsw4qfpqk4kksv0cz96pldxdwxrrw0d5ud5hcqzzx7zt';
-
-    expect(validate(address, Network.regtest)).toBe(true);
-  });
-
-  it('fails on invalid Bech32', () => {
-    const address = 'bc1qw508d6qejxtdg4y5r3zrrvary0c5xw7kv8f3t4';
-
-    expect(validate(address, Network.mainnet)).toBe(false);
+      if (validationAndX === 'Parsing') {
+        test('non-base58 encoded', () => expect(() => getAddressInfo('???')).toThrow());
+      }
+    });
   });
 });


### PR DESCRIPTION
@ruigomeseu awesome work!

I made improvements/simplifications to your testing script to reduce repetition and better group your tests in a more meaningful way. The result is a reduction of more than 110 lines of code and a 2x speed increase in the tests.

To achieve this, I used [describe.each()](https://jestjs.io/docs/api#describeeachtablename-fn-timeout) and [test.each()](https://jestjs.io/docs/api#testeachtablename-fn-timeout) and simple argument conditionals to determine which expectations to assert.

![Test Run Output](https://user-images.githubusercontent.com/65437893/112231406-e4fc8400-8bf3-11eb-8045-b04f7378ce4c.png)

As you can see, the output should now be much cleaner and easier to follow than previously. This also applies to the internals of the file - it should be much easier to find where to debug now.

Lastly, I added an [interface](https://github.com/lbragile/bitcoin-address-validation/blob/master/tests/index.spec.ts#L3) to maintain the type checking of the test file.

Let me know if you have any questions or would like me to fix/adjust/add anything.

Cheers,
Lior
