### PR TITLE
Add support for Taproot address format

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![npm](https://img.shields.io/npm/dt/bitcoin-address-validation.svg)](https://www.npmjs.com/package/bitcoin-address-validation)
 [![Twitter Follow](https://img.shields.io/twitter/follow/8bitgomes.svg?style=social)](https://twitter.com/8bitgomes)
 
-Validate Bitcoin addresses - P2WSH, P2WPKH, P2PKH and P2SH.
+Validate Bitcoin addresses - P2WSH, P2WPKH, P2PKH, P2SH and P2TR.
 
 ```js
 validate('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4');

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -101,6 +101,27 @@ describe('Validation and parsing', () => {
     expect(getAddressInfo(address)).toEqual({ bech32: true, type: 'p2wpkh', network: 'regtest', address });
   });
 
+  it('validates Mainnet Bech32 P2TR', () => {
+    const address = 'bc1ptxs597p3fnpd8gwut5p467ulsydae3rp9z75hd99w8k3ljr9g9rqx6ynaw';
+
+    expect(validate(address)).not.toBe(false);
+    expect(getAddressInfo(address)).toEqual({ bech32: true, type: 'p2tr', network: 'mainnet', address });
+  });
+
+  it('validates Testnet Bech32 P2TR', () => {
+    const address = 'tb1p84x2ryuyfevgnlpnxt9f39gm7r68gwtvllxqe5w2n5ru00s9aquslzggwq';
+
+    expect(validate(address)).not.toBe(false);
+    expect(getAddressInfo(address)).toEqual({ bech32: true, type: 'p2tr', network: 'testnet', address });
+  });
+
+  it('validates Regtest Bech32 P2TR', () => {
+    const address = 'bcrt1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqc8gma6';
+
+    expect(validate(address)).not.toBe(false);
+    expect(getAddressInfo(address)).toEqual({ bech32: true, type: 'p2tr', network: 'regtest', address });
+  });
+
   it('validates Mainnet Bech32 P2WSH', () => {
     const address = 'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3';
 


### PR DESCRIPTION
Taproot addresses start with `bc1p`,  `tb1p`, or `bcrt1p` and have witness version `1`. `bech32m` decoder has to be use instead of `bech32`. 