### PR TITLE
refactor: use Uint8Array instead of Buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "typescript": "^4.1.5"
   },
   "dependencies": {
-    "base-x": "^3.0.8",
+    "@digitalcredentials/base58-universal": "^1.0.1",
     "bech32": "^2.0.0",
-    "sha.js": "^2.4.11"
+    "sha256-uint8array": "^0.10.3"
   }
 }

--- a/src/base58-universal.d.ts
+++ b/src/base58-universal.d.ts
@@ -1,0 +1,1 @@
+declare module '@digitalcredentials/base58-universal';


### PR DESCRIPTION
Webpack 5 does not include Buffer polyfill anymore. This should make this library easier to use in any JavaScript app since Uint8Array works everywhere. 